### PR TITLE
Symfony 4 compatible: made required services public by default

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -7,6 +7,9 @@ imports:
     - { resource: "services/payment_processing.yml" }
 
 services:
+    _defaults:
+        public: true
+
     bitbag_sylius_mollie_plugin.mollie_api_client:
         class: BitBag\SyliusMolliePlugin\Client\MollieApiClient
 

--- a/src/Resources/config/services/action.yml
+++ b/src/Resources/config/services/action.yml
@@ -1,14 +1,15 @@
 services:
+    _defaults:
+        public: true
+
     bitbag_sylius_mollie_plugin.action.capture:
         class: BitBag\SyliusMolliePlugin\Action\CaptureAction
-        public: true
         tags:
             - { name: payum.action, factory: mollie, alias: payum.action.capture }
             - { name: payum.action, factory: mollie_subscription, alias: payum.action.capture }
 
     bitbag_sylius_mollie_plugin.action.notify:
         class: BitBag\SyliusMolliePlugin\Action\NotifyAction
-        public: true
         arguments:
             - "@bitbag_sylius_mollie_plugin.get_http_request"
             - "@bitbag_sylius_mollie_plugin.repository.subscription"
@@ -18,14 +19,12 @@ services:
 
     bitbag_sylius_mollie_plugin.action.status:
         class: BitBag\SyliusMolliePlugin\Action\StatusAction
-        public: true
         tags:
             - { name: payum.action, factory: mollie, alias: payum.action.status }
             - { name: payum.action, factory: mollie_subscription, alias: payum.action.status }
 
     bitbag_sylius_mollie_plugin.action.convert_payment:
         class: BitBag\SyliusMolliePlugin\Action\ConvertPaymentAction
-        public: true
         arguments:
             - "@sylius.payment_description_provider"
         tags:
@@ -39,13 +38,11 @@ services:
 
     bitbag_sylius_mollie_plugin.payum_action.api.create_customer:
         class: BitBag\SyliusMolliePlugin\Action\Api\CreateCustomerAction
-        public: true
         tags:
             - { name: payum.action, factory: mollie_subscription, alias: payum.action.api.create_customer }
 
     bitbag_sylius_mollie_plugin.payum_action.api.create_sepa_mandate:
         class: BitBag\SyliusMolliePlugin\Action\Api\CreateSepaMandateAction
-        public: true
         arguments:
             - "@session"
         tags:
@@ -53,7 +50,6 @@ services:
 
     bitbag_sylius_mollie_plugin.payum_action.api.create_recurring_subscription:
         class: BitBag\SyliusMolliePlugin\Action\Api\CreateRecurringSubscriptionAction
-        public: true
         arguments:
             - "@bitbag_sylius_mollie_plugin.factory.subscription"
             - "@bitbag_sylius_mollie_plugin.manager.subscription"
@@ -64,7 +60,6 @@ services:
 
     bitbag_sylius_mollie_plugin.payum_action.state_machine.status_recurring_subscription:
         class: BitBag\SyliusMolliePlugin\Action\StateMachine\StatusRecurringSubscriptionAction
-        public: true
         arguments:
             - "@bitbag_sylius_mollie_plugin.manager.subscription"
             - "@sm.factory"
@@ -73,6 +68,5 @@ services:
 
     bitbag_sylius_mollie_plugin.payum_action.state_machine.cancel_recurring_subscription:
         class: BitBag\SyliusMolliePlugin\Action\Api\CancelRecurringSubscriptionAction
-        public: true
         tags:
             - { name: payum.action, factory: mollie_subscription, alias: payum.action.state_machine.cancel_recurring_subscription }

--- a/src/Resources/config/services/controller.yml
+++ b/src/Resources/config/services/controller.yml
@@ -1,4 +1,7 @@
 services:
+    _defaults:
+        public: true
+
     bitbag_sylius_mollie_plugin.controller.action.admin.refund:
         class: BitBag\SyliusMolliePlugin\Controller\Action\Admin\Refund
         arguments:

--- a/src/Resources/config/services/gateway_factory.yml
+++ b/src/Resources/config/services/gateway_factory.yml
@@ -1,4 +1,7 @@
 services:
+    _defaults:
+        public: true
+
     bitbag_sylius_mollie_plugin.gateway_factory.mollie:
         class: Payum\Core\Bridge\Symfony\Builder\GatewayFactoryBuilder
         arguments:

--- a/src/Resources/config/services/payment_processing.yml
+++ b/src/Resources/config/services/payment_processing.yml
@@ -1,4 +1,7 @@
 services:
+    _defaults:
+        public: true
+
     bitbag_sylius_mollie_plugin.payment_processing.cancel_recurring_subscription:
         class: BitBag\SyliusMolliePlugin\PaymentProcessing\CancelRecurringSubscriptionProcessor
         arguments:


### PR DESCRIPTION
Related to https://github.com/BitBagCommerce/SyliusMolliePlugin/issues/6
Alternative for https://github.com/BitBagCommerce/SyliusMolliePlugin/pull/5

Tested on Symfony v4.2.4 and Sylius v1.4.1