### PR TITLE
Sylius 1.5 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^7.2",
 
-        "sylius/sylius": "~1.4.0",
+        "sylius/sylius": "1.4.0 - 1.5.0",
         "mollie/mollie-api-php": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
After doing some extensive testing it appears that this bundle works just fine with sylius 1.5.0. To allow projects to be upgraded, this has to be changed in the composer.json file for compatibility reasons.