### PR TITLE
fix (capture): Redirect using GET request

### DIFF
--- a/spec/Action/CaptureActionSpec.php
+++ b/spec/Action/CaptureActionSpec.php
@@ -21,7 +21,7 @@ use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\GatewayAwareInterface;
 use Payum\Core\GatewayInterface;
 use Payum\Core\Payum;
-use Payum\Core\Reply\HttpPostRedirect;
+use Payum\Core\Reply\HttpRedirect;
 use Payum\Core\Request\Capture;
 use Payum\Core\Security\GenericTokenFactory;
 use Payum\Core\Security\GenericTokenFactoryAwareInterface;
@@ -88,7 +88,7 @@ final class CaptureActionSpec extends ObjectBehavior
         $request->getToken()->willReturn($token);
         $payment = \Mockery::mock('payment');
         $payment->id = 1;
-        $payment->shouldReceive('getCheckoutUrl')->andReturn('');
+        $payment->shouldReceive('getCheckoutUrl')->andReturn('https://thisisnotanemptyurl.com');
         $paymentEndpoint->create([
             'amount' => null,
             'description' => null,
@@ -110,7 +110,7 @@ final class CaptureActionSpec extends ObjectBehavior
         $arrayObject->offsetSet('webhookUrl', 'url')->shouldBeCalled();
 
         $this
-            ->shouldThrow(HttpPostRedirect::class)
+            ->shouldThrow(HttpRedirect::class)
             ->during('execute', [$request])
         ;
     }

--- a/src/Action/CaptureAction.php
+++ b/src/Action/CaptureAction.php
@@ -23,7 +23,7 @@ use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Exception\RuntimeException;
 use Payum\Core\GatewayAwareInterface;
 use Payum\Core\GatewayAwareTrait;
-use Payum\Core\Reply\HttpPostRedirect;
+use Payum\Core\Reply\HttpRedirect;
 use Payum\Core\Request\Capture;
 use Payum\Core\Security\GenericTokenFactoryAwareInterface;
 use Payum\Core\Security\GenericTokenFactoryInterface;
@@ -105,7 +105,7 @@ final class CaptureAction extends BaseApiAwareAction implements ActionInterface,
 
             $details['payment_mollie_id'] = $payment->id;
 
-            throw new HttpPostRedirect($payment->getCheckoutUrl());
+            throw new HttpRedirect($payment->getCheckoutUrl());
         }
     }
 


### PR DESCRIPTION
Redirecting to Mollie to start the transaction with a POST request opened the window to select a bank, but displayed the warning "Het formulier is verlopen, probeer het opnieuw" (translated from Dutch: The form has expired, try again).

Tech support from Mollie stated that the request should be a GET request instead of a POST.

Rollback of the change https://github.com/BitBagCommerce/SyliusMolliePlugin/commit/b049a079c20cf6ce4b9aaf271c3a4ad0861be09f.

fix BitBagCommerce/SyliusMolliePlugin#12