### PR TITLE
Add null check for payment method

### DIFF
--- a/src/Processor/PaymentSurchargeProcessor.php
+++ b/src/Processor/PaymentSurchargeProcessor.php
@@ -48,6 +48,10 @@ final class PaymentSurchargeProcessor implements PaymentSurchargeProcessorInterf
         $data = $this->session->get('mollie_payment_options', null);
         $molliePaymentMethod = $data['molliePaymentMethods'];
 
+        if (null === $molliePaymentMethod) {
+            return;
+        }
+        
         $paymentSurcharge = $this->getMolliePaymentSurcharge($paymentMethod, $molliePaymentMethod);
 
         if (null === $paymentSurcharge) {


### PR DESCRIPTION
This allows users to maintain their previously build UI where no payment method was set in the form. For example, we let users choose their method in the Mollie interface and we would like to keep this flow for the time being. Without this check an error is triggered since `$molliePaymentMethod` is null in that case but a string is expected.