### PR TITLE
Bump requirement of Sylius Refund Plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 
         "sylius/sylius": "^1.4.0",
         "mollie/mollie-api-php": "^2.0",
-        "sylius/refund-plugin": "^0.10.1"
+        "sylius/refund-plugin": "^1.0.0-RC.3"
     },
     "require-dev": {
         "behat/behat": "^3.4",


### PR DESCRIPTION
This is necessary since version 0.15 of Sylius Plus ([link](https://github.com/Sylius/PlusInformationCenter/blob/9a27bc9039afef10bb7b038c08d62d74daac9c75/UPGRADE.md#general-update-7)).
The two plugin work together perfectly, and without this requirement it is impossible to use the refund plugin with the mollie plugin.

Alternatively, I can change the requirement to something like `^0.10.1|^1.0.0-RC.3` if that is preferred.