### PR TITLE
Add toggle mollie components

### DIFF
--- a/src/Form/Type/MollieGatewayConfigurationType.php
+++ b/src/Form/Type/MollieGatewayConfigurationType.php
@@ -14,6 +14,7 @@ namespace BitBag\SyliusMolliePlugin\Form\Type;
 
 use BitBag\SyliusMolliePlugin\Payments\PaymentTerms\Options;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -85,6 +86,9 @@ final class MollieGatewayConfigurationType extends AbstractType
             ->add('loggerLevel', ChoiceType::class, [
                 'label' => 'bitbag_sylius_mollie_plugin.ui.debug_level_log',
                 'choices' => Options::getDebugLevels(),
+            ])
+            ->add('components', CheckboxType::class, [
+                'label' => 'bitbag_sylius_mollie_plugin.ui.enable_components',
             ])
             ->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
                 $data = $event->getData();

--- a/src/Resources/public/js/Shop/app.js
+++ b/src/Resources/public/js/Shop/app.js
@@ -5,6 +5,7 @@ $(function () {
     const initialOrderTotal = $('#sylius-summary-grand-total').text();
     const cardActiveClass = "online-payment__item--active";
     const orderTotalRow = $('#sylius-summary-grand-total');
+    const components = Boolean(mollieData.data('components'));
 
     $('input[id*="sylius_checkout_select_payment_"][type=radio]').on('change', ({currentTarget}) => {
         if (!currentTarget.classList.contains('mollie-payments')) {
@@ -52,7 +53,7 @@ $(function () {
         orderTotalRow.text(initialOrderTotal)
     }
 
-    if (mollieData.length > 0) {
+    if (mollieData.length > 0 && true === components) {
         initializeCreditCartFields(selectedValue);
     }
 

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -56,6 +56,7 @@ bitbag_sylius_mollie_plugin:
         split_shipment: 'Split shipment'
         partially_ship: 'Partial ship'
         no_methods_found_message: No methods found. Click the button "Load methods", but first insert You profile Id and API key.
+        enable_components: 'Mollie components (enabled/disabled mollie components on payment methods in checkout)'
     form:
         shipment:
             units: 'Units'

--- a/src/Resources/views/Shop/PaymentMollie/_form.html.twig
+++ b/src/Resources/views/Shop/PaymentMollie/_form.html.twig
@@ -2,6 +2,7 @@
      data-locale="{{ app.request.locale }}"
      data-profile_id="{{ gatewayConfig.config['profile_id'] }}"
      data-environment="{{ gatewayConfig.config['environment'] }}"
+     data-components="{{ gatewayConfig.config['components'] }}"
 >
     {% for keyChoice, choice in methodMollie.vars.choices %}
         <div class="online-payment__item online-payment__item--{{ choice.value }}" id="{{ choice.value }}"
@@ -19,7 +20,7 @@
                 {{ choice.label }}
             </label>
 
-            {% if choice.value == 'creditcard' %}
+            {% if choice.value == 'creditcard' and true == gatewayConfig.config['components'] %}
                 {% include 'BitBagSyliusMolliePlugin:Shop/PaymentMollie:_creditCardForm.html.twig' %}
             {% elseif choice.value == 'ideal' %}
                 {% for key, method in mollie_payment_options %}


### PR DESCRIPTION
Create an option to hide mollie components in credit cart.
Now we can disable components and put credit cart data on the mollie checkout payment