### PR TITLE
Ignore missing payment object to avoid fatal error

### DIFF
--- a/src/Validator/Constraints/PaymentMethodCheckoutValidator.php
+++ b/src/Validator/Constraints/PaymentMethodCheckoutValidator.php
@@ -42,6 +42,10 @@ final class PaymentMethodCheckoutValidator extends ConstraintValidator
         /** @var PaymentInterface $payment */
         $payment = $order->getPayments()->last();
 
+        if ($payment === false) {
+            return;
+        }
+
         /** @var GatewayConfigInterface $gateway */
         $gateway = $payment->getMethod()->getGatewayConfig();
 


### PR DESCRIPTION
I stumbled upon this issue when creating functional test with mollie installed. Happens on PUT /api/v1/checkouts/select-payment/ request. When using cod (Cash on delivery) payment method. In this case mollie payment is not chosen but mollie validator is still triggered. And it is failing because no payment exists at the time of it being called.

```
Error: Call to a member function getMethod() on bool

/var/www/app/vendor/bitbag/mollie-plugin/src/Validator/Constraints/PaymentMethodCheckoutValidator.php:46
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:609
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:117
/var/www/app/vendor/symfony/form/Extension/Validator/Constraints/FormValidator.php:135
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:609
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:117
/var/www/app/vendor/symfony/form/Extension/Validator/Constraints/FormValidator.php:142
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:609
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:117
/var/www/app/vendor/symfony/form/Extension/Validator/Constraints/FormValidator.php:142
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:609
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:117
/var/www/app/vendor/symfony/form/Extension/Validator/Constraints/FormValidator.php:142
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:609
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:117
/var/www/app/vendor/symfony/form/Extension/Validator/Constraints/FormValidator.php:142
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:492
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:315
/var/www/app/vendor/symfony/validator/Validator/RecursiveContextualValidator.php:138
/var/www/app/vendor/symfony/validator/Validator/RecursiveValidator.php:93
/var/www/app/vendor/symfony/validator/Validator/TraceableValidator.php:66
/var/www/app/vendor/symfony/form/Extension/Validator/EventListener/ValidationListener.php:50
/var/www/app/vendor/symfony/event-dispatcher/EventDispatcher.php:264
/var/www/app/vendor/symfony/event-dispatcher/EventDispatcher.php:239
/var/www/app/vendor/symfony/event-dispatcher/EventDispatcher.php:73
/var/www/app/vendor/symfony/event-dispatcher/ImmutableEventDispatcher.php:44
/var/www/app/vendor/symfony/form/Form.php:671
/var/www/app/vendor/sylius/resource-bundle/src/Bundle/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php:107
/var/www/app/vendor/symfony/form/Form.php:493
/var/www/app/vendor/sylius/resource-bundle/src/Bundle/Controller/ResourceController.php:264
/var/www/app/vendor/symfony/http-kernel/HttpKernel.php:158
/var/www/app/vendor/symfony/http-kernel/HttpKernel.php:80
/var/www/app/vendor/symfony/http-kernel/Kernel.php:201
/var/www/app/vendor/symfony/http-kernel/Client.php:65
/var/www/app/vendor/symfony/framework-bundle/Client.php:131
/var/www/app/vendor/symfony/browser-kit/Client.php:404
/var/www/app/test/src/Functional/Weclapp/FullOrderWorkflowTest.php:181
/var/www/app/test/src/Functional/Weclapp/FullOrderWorkflowTest.php:44
```

It is possible to recreate using Sylius\Tests\Controller\CheckoutApiTestCase test case. It fails at ::selectOrderPaymentMethod().
I was using this test as template for my own case with the difference that I have mollie installed and it fails then. This is one of 2 fixes I have for this. Other one will be posted in separate PR.