### PR TITLE
Set default sylius payment selector to avoid failure during form type…

### DIFF
--- a/src/Resources/config/services/form.xml
+++ b/src/Resources/config/services/form.xml
@@ -79,5 +79,10 @@
             <argument>%bitbag_sylius_mollie_plugin.model.template_mollie_email_translation.class%</argument>
             <tag name="form.type" />
         </service>
+        <service id="sylius.form.type.checkout_select_payment" class="Sylius\Bundle\CoreBundle\Form\Type\Checkout\SelectPaymentType">
+            <argument>%sylius.model.order.class%</argument>
+            <argument>%sylius.form.type.checkout_select_payment.validation_groups%</argument>
+            <tag name="form.type" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
This is second issue I had while creating functional order test with mollie installed. Happens on PUT /api/v1/checkouts/select-payment/ request. When using cod (Cash on delivery) payment method.

```
ArgumentCountError: Too few arguments to function Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType::__construct(), 0 passed in /var/www/app/vendor/symfony/form/FormRegistry.php on line 91 and at least 1 expected

/var/www/app/vendor/sylius/resource-bundle/src/Bundle/Form/Type/AbstractResourceType.php:32
/var/www/app/vendor/symfony/form/FormRegistry.php:91
/var/www/app/vendor/symfony/form/FormFactory.php:74
/var/www/app/vendor/symfony/form/FormFactory.php:38
/var/www/app/vendor/sylius/resource-bundle/src/Bundle/Controller/ResourceFormFactory.php:42
```

I figured that others also are struggling with this issue because there is post that is proposing a fix for it here: https://gitmemory.com/issue/Sylius/PayPalPlugin/154/724763754

I think it is related to `Sylius\PayPalPlugin\SyliusPayPalPlugin` being installed next to Mollie (but I can not confirm or deny it). It is overriding `Sylius\Bundle\CoreBundle\Form\Type\Checkout\SelectPaymentType` and then this default value is lost for Mollie. And so sylius is not able to find correct payment selector.

Let me know if this is not related to Mollie bundle. In the end can be fixed with config directly in `src/Resources/config/services.xml`
