### PR TITLE
Fix namespace syntax

### DIFF
--- a/src/Controller/Action/Admin/GeneratePaymentlinkAction.php
+++ b/src/Controller/Action/Admin/GeneratePaymentlinkAction.php
@@ -89,7 +89,7 @@ final class GeneratePaymentlinkAction
                 $this->loggerAction->addLog(sprintf('Created payment link to order with id = %s', $order->getId()));
 
                 return new RedirectResponse($this->router->generate('sylius_admin_order_show', ['id' => $order->getId()]));
-            } catch (\ Exception $e) {
+            } catch (\Exception $e) {
                 $this->loggerAction->addNegativeLog(sprintf('Error with generate payment link with : %s', $e->getMessage()));
 
                 $this->session->getFlashBag()->add('error', $e->getMessage());


### PR DESCRIPTION
Parsing this file with https://github.com/nikic/PHP-Parser (v4.7.0 and above) fails because the parser switched to the new namespace tokenization rules https://wiki.php.net/rfc/namespaced_names_as_token.
Related issue: https://github.com/nikic/PHP-Parser/issues/700
Detected using https://github.com/maglnet/ComposerRequireChecker v3.2.0.
PHP version: 7.4.16
