### PR TITLE
Check if Sylius 1.9 migration is already executed

### DIFF
--- a/src/Migrations/Version20210326134353.php
+++ b/src/Migrations/Version20210326134353.php
@@ -7,9 +7,6 @@ namespace BitBag\SyliusMolliePlugin\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 final class Version20210326134353 extends AbstractMigration
 {
     public function getDescription() : string
@@ -19,7 +16,14 @@ final class Version20210326134353 extends AbstractMigration
 
     public function up(Schema $schema) : void
     {
-        // this up() migration is auto-generated, please modify it to your needs
+        $adjustmentTableAltered = $schema->getTable('sylius_adjustment')->hasColumn('shipment_id');
+        $channelTableAltered = $schema->getTable('sylius_channel')->hasColumn('contact_phone_number');
+        $attributeTableAltered = $schema->getTable('sylius_product_attribute')->hasColumn('translatable');
+        $shipmentTableAltered = $schema->getTable('sylius_shipment')->hasColumn('adjustments_total');
+        if ($adjustmentTableAltered && $channelTableAltered && $attributeTableAltered && $shipmentTableAltered) {
+            return;
+        }
+
         $this->addSql('ALTER TABLE sylius_adjustment ADD shipment_id INT DEFAULT NULL, ADD details JSON NOT NULL');
         $this->addSql('ALTER TABLE sylius_adjustment ADD CONSTRAINT FK_ACA6E0F27BE036FC FOREIGN KEY (shipment_id) REFERENCES sylius_shipment (id) ON DELETE CASCADE');
         $this->addSql('CREATE INDEX IDX_ACA6E0F27BE036FC ON sylius_adjustment (shipment_id)');
@@ -31,7 +35,6 @@ final class Version20210326134353 extends AbstractMigration
 
     public function down(Schema $schema) : void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_adjustment DROP FOREIGN KEY FK_ACA6E0F27BE036FC');
         $this->addSql('DROP INDEX IDX_ACA6E0F27BE036FC ON sylius_adjustment');
         $this->addSql('ALTER TABLE sylius_adjustment DROP shipment_id, DROP details');


### PR DESCRIPTION
Fixes #132

This behaviour is also used within Sylius (for example in the refund plugin) to make sure these exact same table alterations are not being executed twice on Sylius 1.9.