### PR TITLE
Adapt for new Sylius style of template includes

### DIFF
--- a/src/Resources/views/Admin/Logger/Grid/_theme.html.twig
+++ b/src/Resources/views/Admin/Logger/Grid/_theme.html.twig
@@ -1,2 +1,2 @@
-{% form_theme form '@SyliusUiBundle:Form:theme.html.twig' %}
+{% form_theme form '@SyliusUi/Form/theme.html.twig' %}
 {{ form_row(form) }}


### PR DESCRIPTION
In commit 755493675e0560219d9c632fea3f4a878c4d16b5 the `form_theme` include was changed, but it did (or now does) not actually find the theme:

> Uncaught PHP Exception Twig\Error\LoaderError: "Unable to find template "SyliusUiBundle:Form:theme.html.twig" 

This PR changes the include path and has been tested (Sylius admin > Mollie logger).