### PR TITLE
Fix deprecation required parameter follows optional parameter

### DIFF
--- a/src/Form/Type/MollieGatewayConfigType.php
+++ b/src/Form/Type/MollieGatewayConfigType.php
@@ -42,9 +42,9 @@ final class MollieGatewayConfigType extends AbstractResourceType
 
     public function __construct(
         string $dataClass,
-        array $validationGroups = [],
         DocumentationLinksInterface $documentationLinks,
-        string $defaultLocale
+        string $defaultLocale,
+        array $validationGroups = []
     ) {
         parent::__construct($dataClass, $validationGroups);
         $this->documentationLinks = $documentationLinks;

--- a/src/Resources/config/services/form.xml
+++ b/src/Resources/config/services/form.xml
@@ -46,9 +46,9 @@
         </service>
         <service id="bitbag_sylius_mollie_plugin.form.extension.mollie_gateway_config" class="BitBag\SyliusMolliePlugin\Form\Type\MollieGatewayConfigType">
             <argument>%bitbag_sylius_mollie_plugin.model.mollie_gateway_config.class%</argument>
-            <argument>%bitbag_sylius_mollie_plugin.form.type.payment_methods.validation_groups.transport%</argument>
             <argument type="service" id="bitbag_sylius_mollie_plugin.documentation.documentation_links"/>
             <argument>%sylius_locale.locale%</argument>
+            <argument>%bitbag_sylius_mollie_plugin.form.type.payment_methods.validation_groups.transport%</argument>
             <tag name="form.type"/>
         </service>
         <service id="bitbag_sylius_mollie_plugin.form.type.payment_surcharge_fee" class="BitBag\SyliusMolliePlugin\Form\Type\PaymentSurchargeFeeType">


### PR DESCRIPTION
Optional parameters should follow the required ones:

https://php.watch/versions/8.0/deprecate-required-param-after-optional

