### PR TITLE
Fix Mollie <=> Sylius Refund connection

### DIFF
--- a/src/Action/NotifyAction.php
+++ b/src/Action/NotifyAction.php
@@ -16,10 +16,6 @@ use BitBag\SyliusMolliePlugin\Action\StateMachine\SetStatusOrderAction;
 use BitBag\SyliusMolliePlugin\Entity\MollieSubscriptionInterface;
 use BitBag\SyliusMolliePlugin\Logger\MollieLoggerActionInterface;
 use BitBag\SyliusMolliePlugin\Repository\MollieSubscriptionRepositoryInterface;
-use BitBag\SyliusMolliePlugin\Request\Api\ConfigureNextOrder;
-use BitBag\SyliusMolliePlugin\Request\Api\CreateMollieSubscription;
-use BitBag\SyliusMolliePlugin\Request\Api\CreateOnDemandSubscription;
-use BitBag\SyliusMolliePlugin\Request\Api\CreateOnDemandSubscriptionPayment;
 use BitBag\SyliusMolliePlugin\Request\StateMachine\StatusRecurringSubscription;
 use Mollie\Api\Exceptions\ApiException;
 use Payum\Core\Action\ActionInterface;
@@ -54,8 +50,7 @@ final class NotifyAction extends BaseApiAwareAction implements ActionInterface, 
         MollieSubscriptionRepositoryInterface $subscriptionRepository,
         SetStatusOrderAction $setStatusOrderAction,
         MollieLoggerActionInterface $loggerAction
-    )
-    {
+    ) {
         $this->getHttpRequest = $getHttpRequest;
         $this->subscriptionRepository = $subscriptionRepository;
         $this->setStatusOrderAction = $setStatusOrderAction;
@@ -69,8 +64,6 @@ final class NotifyAction extends BaseApiAwareAction implements ActionInterface, 
 
         $details = ArrayObject::ensureArrayObject($request->getModel());
         $this->gateway->execute($this->getHttpRequest);
-
-        $details['created_in_mollie'] = true;
 
         if (true === isset($details['sequenceType'])) {
             try {

--- a/src/Action/RefundAction.php
+++ b/src/Action/RefundAction.php
@@ -50,6 +50,10 @@ final class RefundAction extends BaseApiAwareAction implements ActionInterface, 
 
         $details = ArrayObject::ensureArrayObject($request->getModel());
 
+        if (!array_key_exists('refund', $details['metadata'])) {
+            return;
+        }
+
         try {
             $molliePayment = $this->mollieApiClient->payments->get($details['payment_mollie_id']);
         } catch (ApiException $e) {

--- a/src/Action/RefundAction.php
+++ b/src/Action/RefundAction.php
@@ -50,9 +50,15 @@ final class RefundAction extends BaseApiAwareAction implements ActionInterface, 
 
         $details = ArrayObject::ensureArrayObject($request->getModel());
 
-        if ($details['created_in_mollie']) {
-            $this->loggerAction->addLog('Received refund created in Mollie dashboard');
+        try {
+            $molliePayment = $this->mollieApiClient->payments->get($details['payment_mollie_id']);
+        } catch (ApiException $e) {
+            $this->loggerAction->addNegativeLog(sprintf('API call failed: %s', htmlspecialchars($e->getMessage())));
 
+            throw new \Exception(sprintf('API call failed: %s', htmlspecialchars($e->getMessage())));
+        }
+
+        if ($molliePayment->hasRefunds()) {
             return;
         }
 
@@ -60,7 +66,6 @@ final class RefundAction extends BaseApiAwareAction implements ActionInterface, 
         $payment = $request->getFirstModel();
 
         try {
-            $molliePayment = $this->mollieApiClient->payments->get($details['payment_mollie_id']);
             $refundData = $this->convertOrderRefundData->convert($details['metadata']['refund'], $payment->getCurrencyCode());
 
             if (true === $molliePayment->canBeRefunded()) {


### PR DESCRIPTION
`'created_in_mollie' `flag was sticking to every payment object, which then prevents from refund because of condition